### PR TITLE
change readme to describe correct python version + instructions on creating conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,26 @@ This repo refers to the paper "*Sim-to-real Deep Reinforcement Learning for Comp
 
 
 ### Installation ###
-This repo has only been developed and tested with Ubuntu 18.04 and python 3.8.
+This repo has only been developed and tested with Ubuntu 18.04 and python 3.10.
 
+Clone the repository:
 ```console
 git clone https://github.com/dexterousrobot/tactile_gym
 cd tactile_gym
+```
+
+To create a conda environment (recommended)
+```
+conda env create -n tactile_gym python=3.10
+conda activate tactile_gym
+```
+
+To install dependencies:
+```console
 pip install -e .
 ```
 
 Demonstration files are provided in the example directory. From the base directory run
-
 ```
 python examples/demo_env.py -env example_arm-v0
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ To install dependencies:
 pip install -e .
 ```
 
+You will also need to install the [Common Robot Interface](https://github.com/robot-dexterity/common-robot-interface), with e.g.:
+```console
+cd ..
+git clone https://github.com/robot-dexterity/common-robot-interface
+cd common-robot-interface
+pip install -e .
+cd ../tactile-gym-3/
+```
+
 Demonstration files are provided in the example directory. From the base directory run
 ```
 python examples/demo_env.py -env example_arm-v0


### PR DESCRIPTION
Changed python 3.8 -> 3.10 in readme (to match the version required by requirements.txt), and add a line on creating a conda environment before running `pip install -e .` (otherwise it'll install in your base python environment, which is probably the wrong thing to do)